### PR TITLE
fix: correct temporary price calculation and add logging for buy/sell…

### DIFF
--- a/packages/tse-backend/src/modules/trading-strategy/strategies/volume/volume.strategy.ts
+++ b/packages/tse-backend/src/modules/trading-strategy/strategies/volume/volume.strategy.ts
@@ -483,7 +483,7 @@ export class VolumeStrategy implements Strategy {
       /* need more quote, so sell base for quote */
       const baseToSell = amountNeeded.div(price);
       if (baseToSell.gt(0)) {
-        const tempPrice = price * 1.1;
+        const tempPrice = price * 0.90;
         const amount = (baseToSell.mul(tempPrice).gte(1)) ? baseToSell : new Decimal(1).div(tempPrice);
         await exch.createOrder(pair, MarketOrderType.MARKET_ORDER, TradeSideType.SELL, amount, price);
       }


### PR DESCRIPTION
… actions in VolumeStrategy

- Adjusted the temporary price calculation for sell orders to use a multiplier of 0.90 instead of 1.1.
- Added console logging for buy and sell actions to improve traceability of order amounts and prices.